### PR TITLE
fix: oferts and posts inactive check

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,4 +38,3 @@ async function bootstrap() {
   await app.listen(port ?? 3000);
 }
 bootstrap();
-


### PR DESCRIPTION
Now when the route get/sponsor/[id] gets called, it checks the date of the offerts and posts and puts inactive to the ones that the validUntil date is less than today's date